### PR TITLE
European analytic pricer

### DIFF
--- a/src/enums.py
+++ b/src/enums.py
@@ -48,4 +48,3 @@ class Measure(str, Enum):
 class GreekMethod(str, Enum):
     ANALYTIC: str = 'ANALYTIC'
     BUMP: str = 'BUMP'
-

--- a/src/model.py
+++ b/src/model.py
@@ -16,14 +16,25 @@ class MarketModel(ABC):
     def get_rate(self) -> float:
         return self._interest_rate
 
+    def bump_rate(self, bump_size: float) -> None:
+        self._interest_rate += bump_size
+
     def get_initial_spot(self) -> float:
         return self._initial_spot
+
+    def bump_initial_spot(self, bump_size: float) -> None:
+        self._initial_spot += bump_size
 
     def get_volgrid(self) -> VolGrid:
         return self._volgrid
 
-    def get_df(self, t: float) -> float:
-        return np.exp(-self.interest_rate * t)
+    def bump_volgrid(self, bump_size: float) -> None:
+        values = self._volgrid.get_values()
+        values += bump_size
+        self._volgrid = VolGrid(self._volgrid.get_und(), self._volgrid.get_points(), values)
+
+    def get_df(self, tenor: float) -> float:
+        return np.exp(-1.0 * self._interest_rate * tenor)
 
     @abstractmethod
     def get_simulated_spot(self, t: float, Z: float) -> float:
@@ -38,24 +49,23 @@ class BSVolModel(MarketModel):
     def __init__(self, und: Stock):
         super().__init__(und)
 
-    def get_vol(self) -> float:
-        return self.get_volgrid.get_vol(1.0, 1.0)
+    def get_vol(self, tenor: float, moneyness: float) -> float:
+        # Black-Scholes model always returns the same volatility for a given underlying
+        return self.get_volgrid().get_vol(1.0, 1.0)
 
     def get_simulated_spot(self, t: float, Z: float) -> float:
-        return np.exp(
-            (self.interest_rate * t - 0.5 * self.get_vol() ** 2 * t) + (self.get_vol() * Z * np.sqrt(t)))
+        return np.exp((self._interest_rate * t - 0.5 * self.get_vol() ** 2 * t) + (self.get_vol() * Z * np.sqrt(t)))
 
 
 class FlatVolModel(MarketModel):
     def __init__(self, und: Stock):
         super().__init__(und)
 
-    def get_vol(self, t: float, strike: float) -> float:
-        return self.get_volgrid.get_vol(t, strike)
+    def get_vol(self, tenor: float, moneyness: float) -> float:
+        return self.get_volgrid().get_vol(tenor, moneyness)
 
     def get_simulated_spot(self, t: float, strike: float, Z: float) -> float:
         vol = self.get_vol(t, strike)
-        return np.exp(
-            (self.interest_rate * t - 0.5 * vol ** 2 * t) + (vol * Z * np.sqrt(t)))
+        return np.exp((self._interest_rate * t - 0.5 * vol ** 2 * t) + (vol * Z * np.sqrt(t)))
 
 

--- a/src/numerical_method.py
+++ b/src/numerical_method.py
@@ -38,8 +38,8 @@ class TreeMethod(NumericalMethod):
 
 
 class AnalyticMethod(NumericalMethod):
-    def __new__():
-        raise NotImplementedError('AnalyticMethod class cannot be instantiated')
+    def __init__(self, model: MarketModel):
+        super().__init__(model, Params())
 
 
 class Params(ABC):

--- a/src/pricer.py
+++ b/src/pricer.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
+import copy
 from src.enums import *
 from src.contract import *
 from src.model import *
 from src.numerical_method import *
+from scipy.stats import norm
 
 
 class Pricer(ABC):
+    RELATIVE_BUMP_SIZE: float = 0.01
+
     def __init__(self, contract: Contract, model: MarketModel, method: NumericalMethod):
         self._contract = contract
         self._model = model
@@ -40,10 +44,205 @@ class Pricer(ABC):
     def calc_rho(self, method: GreekMethod) -> float:
         pass
 
+    def _raise_unsupported_greek_method_error(
+            self,
+            method: str,
+            supported: tuple[GreekMethod] = (x.value for x in GreekMethod)) -> None:
+        raise ValueError(f'Unsupported GreekMethod {method} for Pricer {type(self).__name__}. '
+                         f'Supported methods are: {", ".join(supported)}')
 
-# todo: to be implemented
+
 class EuropeanAnalyticPricer(Pricer):
-    pass
+    @staticmethod
+    def __d1(spot: float, strike: float, vol: float, rate: float, tenor: float):
+        return 1 / (vol * np.sqrt(tenor)) * (np.log(spot / strike) + (rate + vol**2 / 2) * tenor)
+
+    @staticmethod
+    def __d2(spot: float, strike: float, vol: float, rate: float, tenor: float):
+        d1 = EuropeanAnalyticPricer.__d1(spot, strike, vol, rate, tenor)
+        return d1 - vol * np.sqrt(tenor)
+
+    def __init__(self, contract: EuropeanContract, model: MarketModel, method: AnalyticMethod):
+        if not isinstance(contract, EuropeanContract):
+            raise TypeError(f'Contract must be of type EuropeanContract but received {type(contract).__name__}')
+        if not isinstance(method, AnalyticMethod):
+            raise TypeError(f'Method must be of type AnalyticMethod but received {type(method).__name__}')
+        super().__init__(contract, model, method)
+
+    def calc_fair_value(self) -> float:
+        direction = self._contract.get_direction()
+        strike = self._contract.get_strike()
+        tenor = self._contract.get_expiry()
+        if tenor < 1e-8:
+            # return zero if option expired
+            return 0.0
+        spot = self._model.get_initial_spot()
+        vol = self._model.get_vol(tenor, spot / strike)
+        rate = self._model.get_rate()
+        df = self._model.get_df(tenor)
+        d1 = EuropeanAnalyticPricer.__d1(spot, strike, vol, rate, tenor)
+        d2 = EuropeanAnalyticPricer.__d2(spot, strike, vol, rate, tenor)
+        if self._contract.get_type() == PutCallFwd.CALL:
+            return direction * (spot * norm.cdf(d1) - strike * df * norm.cdf(d2))
+        elif self._contract.get_type() == PutCallFwd.PUT:
+            return direction * (strike * df * norm.cdf(-d2) - spot * norm.cdf(-d1))
+        else:
+            self.__raise_incorrect_derivative_type_error()
+
+    def calc_delta(self, method: GreekMethod) -> float:
+        spot = self._model.get_initial_spot()
+        if method == GreekMethod.ANALYTIC:
+            greek = 0.0
+            direction = self._contract.get_direction()
+            strike = self._contract.get_strike()
+            tenor = self._contract.get_expiry()
+            vol = self._model.get_volgrid().get_vol(tenor, spot / strike)
+            rate = self._model.get_rate()
+            d1 = EuropeanAnalyticPricer.__d1(spot, strike, vol, rate, tenor)
+            if self._contract.get_type() == PutCallFwd.CALL:
+                greek = norm.cdf(d1)
+            elif self._contract.get_type() == PutCallFwd.PUT:
+                greek = -norm.cdf(-d1)
+            else:
+                self.__raise_incorrect_derivative_type_error()
+            return direction * greek
+        elif method == GreekMethod.BUMP:
+            bump_size = self.RELATIVE_BUMP_SIZE * spot
+            bumped_fair_values = list()
+            for b in (bump_size, -bump_size):
+                model = copy.deepcopy(self._model)
+                model.bump_initial_spot(b)
+                bumped_pricer = globals()[type(self).__name__](self._contract, model, self._method)
+                bumped_fair_values.append(bumped_pricer.calc_fair_value())
+                del bumped_pricer
+                del model
+            return (bumped_fair_values[0] - bumped_fair_values[1]) / (2 * bump_size)
+        else:
+            self._raise_unsupported_greek_method_error(method)
+
+    def calc_gamma(self, method: GreekMethod) -> float:
+        spot = self._model.get_initial_spot()
+        if method == GreekMethod.ANALYTIC:
+            greek = 0.0
+            direction = self._contract.get_direction()
+            strike = self._contract.get_strike()
+            tenor = self._contract.get_expiry()
+            vol = self._model.get_volgrid().get_vol(tenor, spot / strike)
+            rate = self._model.get_rate()
+            if self._contract.get_type() in (PutCallFwd.CALL, PutCallFwd.PUT):
+                d1 = EuropeanAnalyticPricer.__d1(spot, strike, vol, rate, tenor)
+                greek = norm.pdf(d1) / (spot * vol * np.sqrt(tenor))
+            else:
+                self.__raise_incorrect_derivative_type_error()
+            return direction * greek
+        elif method == GreekMethod.BUMP:
+            bump_size = self.RELATIVE_BUMP_SIZE * spot
+            bumped_fair_values = list()
+            for b in (bump_size, -bump_size):
+                model = copy.deepcopy(self._model)
+                model.bump_initial_spot(b)
+                bumped_pricer = globals()[type(self).__name__](self._contract, model, self._method)
+                bumped_fair_values.append(bumped_pricer.calc_fair_value())
+                del bumped_pricer
+                del model
+            return (bumped_fair_values[0] - 2 * self.calc_fair_value() + bumped_fair_values[1]) / (bump_size ** 2)
+        else:
+            self._raise_unsupported_greek_method_error(method)
+
+    def calc_vega(self, method: GreekMethod) -> float:
+        spot = self._model.get_initial_spot()
+        strike = self._contract.get_strike()
+        tenor = self._contract.get_expiry()
+        vol = self._model.get_volgrid().get_vol(tenor, spot / strike)
+        if method == GreekMethod.ANALYTIC:
+            greek = 0.0
+            direction = self._contract.get_direction()
+            rate = self._model.get_rate()
+            df = self._model.get_df(tenor)
+            if self._contract.get_type() in (PutCallFwd.CALL, PutCallFwd.PUT):
+                d2 = EuropeanAnalyticPricer.__d2(spot, strike, vol, rate, tenor)
+                greek = strike * df * norm.pdf(d2) * np.sqrt(tenor)
+            else:
+                self.__raise_incorrect_derivative_type_error()
+            return direction * greek
+        elif method == GreekMethod.BUMP:
+            bump_size = self.RELATIVE_BUMP_SIZE * vol
+            bumped_fair_values = list()
+            for b in (bump_size, -bump_size):
+                model = copy.deepcopy(self._model)
+                model.bump_volgrid(b)
+                bumped_pricer = globals()[type(self).__name__](self._contract, model, self._method)
+                bumped_fair_values.append(bumped_pricer.calc_fair_value())
+                del bumped_pricer
+                del model
+            return (bumped_fair_values[0] - bumped_fair_values[1]) / (2 * bump_size)
+        else:
+            self._raise_unsupported_greek_method_error(method)
+
+    def calc_theta(self, method: GreekMethod) -> float:
+        tenor = self._contract.get_expiry()
+        if method == GreekMethod.ANALYTIC:
+            greek = 0.0
+            direction = self._contract.get_direction()
+            strike = self._contract.get_strike()
+            spot = self._model.get_initial_spot()
+            vol = self._model.get_volgrid().get_vol(tenor, spot / strike)
+            rate = self._model.get_rate()
+            df = self._model.get_df(tenor)
+            d1 = EuropeanAnalyticPricer.__d1(spot, strike, vol, rate, tenor)
+            d2 = EuropeanAnalyticPricer.__d2(spot, strike, vol, rate, tenor)
+            if self._contract.get_type() == PutCallFwd.CALL:
+                greek = -1.0 * ((spot * norm.pdf(d1) * vol) / (2 * np.sqrt(tenor)) + rate * strike * df * norm.cdf(d2))
+            elif self._contract.get_type() == PutCallFwd.PUT:
+                greek = -1.0 * ((spot * norm.pdf(d1) * vol) / (2 * np.sqrt(tenor)) - rate * strike * df * norm.cdf(-d2))
+            else:
+                self.__raise_incorrect_derivative_type_error()
+            return direction * greek
+        elif method == GreekMethod.BUMP:
+            bump_size = 1.0 / 252.0
+            contract = copy.deepcopy(self._contract)
+            contract.set_expiry(tenor + bump_size)
+            bumped_pricer = globals()[type(self).__name__](contract, self._model, self._method)
+            bumped_fair_value = bumped_pricer.calc_fair_value()
+            del bumped_pricer
+            return -1.0 * (bumped_fair_value - self.calc_fair_value()) / bump_size
+        else:
+            self._raise_unsupported_greek_method_error(method)
+
+    def calc_rho(self, method: GreekMethod) -> float:
+        rate = self._model.get_rate()
+        if method == GreekMethod.ANALYTIC:
+            greek = 0.0
+            direction = self._contract.get_direction()
+            strike = self._contract.get_strike()
+            tenor = self._contract.get_expiry()
+            spot = self._model.get_initial_spot()
+            vol = self._model.get_volgrid().get_vol(tenor, spot / strike)
+            df = self._model.get_df(tenor)
+            d2 = EuropeanAnalyticPricer.__d2(spot, strike, vol, rate, tenor)
+            if self._contract.get_type() == PutCallFwd.CALL:
+                greek = strike * tenor * df * norm.cdf(d2)
+            elif self._contract.get_type() == PutCallFwd.PUT:
+                greek = -strike * tenor * df * norm.cdf(-d2)
+            else:
+                self.__raise_incorrect_derivative_type_error()
+            return direction * greek
+        elif method == GreekMethod.BUMP:
+            bump_size = self.RELATIVE_BUMP_SIZE * rate
+            bumped_fair_values = list()
+            for b in (bump_size, -bump_size):
+                model = copy.deepcopy(self._model)
+                model.bump_rate(b)
+                bumped_pricer = globals()[type(self).__name__](self._contract, model, self._method)
+                bumped_fair_values.append(bumped_pricer.calc_fair_value())
+                del bumped_pricer
+                del model
+            return (bumped_fair_values[0] - bumped_fair_values[1]) / (2 * bump_size)
+        else:
+            self._raise_unsupported_greek_method_error(method)
+
+    def __raise_incorrect_derivative_type_error(self) -> None:
+        raise ValueError(f'Derivative type of {type(self._contract).__name__} must be CALL or PUT')
 
 
 # todo: to be implemented

--- a/src/pricer.py
+++ b/src/pricer.py
@@ -24,25 +24,77 @@ class Pricer(ABC):
     def calc_fair_value(self) -> float:
         pass
 
-    @abstractmethod
     def calc_delta(self, method: GreekMethod) -> float:
-        pass
+        if method != GreekMethod.BUMP:
+            self._raise_unsupported_greek_method_error(method, (GreekMethod.BUMP,))
+        bump_size = self.RELATIVE_BUMP_SIZE * self._model.get_initial_spot()
+        bumped_fair_values = list()
+        for b in (bump_size, -bump_size):
+            model = copy.deepcopy(self._model)
+            model.bump_initial_spot(b)
+            bumped_pricer = globals()[type(self).__name__](self._contract, model, self._method)
+            bumped_fair_values.append(bumped_pricer.calc_fair_value())
+            del bumped_pricer
+            del model
+        return (bumped_fair_values[0] - bumped_fair_values[1]) / (2 * bump_size)
 
-    @abstractmethod
     def calc_gamma(self, method: GreekMethod) -> float:
-        pass
+        if method != GreekMethod.BUMP:
+            self._raise_unsupported_greek_method_error(method, (GreekMethod.BUMP,))
+        bump_size = self.RELATIVE_BUMP_SIZE * self._model.get_initial_spot()
+        bumped_fair_values = list()
+        for b in (bump_size, -bump_size):
+            model = copy.deepcopy(self._model)
+            model.bump_initial_spot(b)
+            bumped_pricer = globals()[type(self).__name__](self._contract, model, self._method)
+            bumped_fair_values.append(bumped_pricer.calc_fair_value())
+            del bumped_pricer
+            del model
+        return (bumped_fair_values[0] - 2 * self.calc_fair_value() + bumped_fair_values[1]) / (bump_size ** 2)
 
-    @abstractmethod
     def calc_vega(self, method: GreekMethod) -> float:
-        pass
+        if method != GreekMethod.BUMP:
+            self._raise_unsupported_greek_method_error(method, (GreekMethod.BUMP,))
+        spot = self._model.get_initial_spot()
+        strike = self._contract.get_strike()
+        tenor = self._contract.get_expiry()
+        vol = self._model.get_volgrid().get_vol(tenor, spot / strike)
+        bump_size = self.RELATIVE_BUMP_SIZE * vol
+        bumped_fair_values = list()
+        for b in (bump_size, -bump_size):
+            model = copy.deepcopy(self._model)
+            model.bump_volgrid(b)
+            bumped_pricer = globals()[type(self).__name__](self._contract, model, self._method)
+            bumped_fair_values.append(bumped_pricer.calc_fair_value())
+            del bumped_pricer
+            del model
+        return (bumped_fair_values[0] - bumped_fair_values[1]) / (2 * bump_size)
 
-    @abstractmethod
     def calc_theta(self, method: GreekMethod) -> float:
-        pass
+        if method != GreekMethod.BUMP:
+            self._raise_unsupported_greek_method_error(method, (GreekMethod.BUMP,))
+        bump_size = 1.0 / 252.0
+        contract = copy.deepcopy(self._contract)
+        contract.set_expiry(self._contract.get_expiry() + bump_size)
+        bumped_pricer = globals()[type(self).__name__](contract, self._model, self._method)
+        bumped_fair_value = bumped_pricer.calc_fair_value()
+        del bumped_pricer
+        del contract
+        return -1.0 * (bumped_fair_value - self.calc_fair_value()) / bump_size
 
-    @abstractmethod
     def calc_rho(self, method: GreekMethod) -> float:
-        pass
+        if method != GreekMethod.BUMP:
+            self._raise_unsupported_greek_method_error(method, (GreekMethod.BUMP,))
+        bump_size = self.RELATIVE_BUMP_SIZE * self._model.get_rate()
+        bumped_fair_values = list()
+        for b in (bump_size, -bump_size):
+            model = copy.deepcopy(self._model)
+            model.bump_rate(b)
+            bumped_pricer = globals()[type(self).__name__](self._contract, model, self._method)
+            bumped_fair_values.append(bumped_pricer.calc_fair_value())
+            del bumped_pricer
+            del model
+        return (bumped_fair_values[0] - bumped_fair_values[1]) / (2 * bump_size)
 
     def _raise_unsupported_greek_method_error(
             self,
@@ -74,8 +126,7 @@ class EuropeanAnalyticPricer(Pricer):
         strike = self._contract.get_strike()
         tenor = self._contract.get_expiry()
         if tenor < 1e-8:
-            # return zero if option expired
-            return 0.0
+            return 0.0  # return zero if option expired
         spot = self._model.get_initial_spot()
         vol = self._model.get_vol(tenor, spot / strike)
         rate = self._model.get_rate()
@@ -90,10 +141,9 @@ class EuropeanAnalyticPricer(Pricer):
             self.__raise_incorrect_derivative_type_error()
 
     def calc_delta(self, method: GreekMethod) -> float:
-        spot = self._model.get_initial_spot()
         if method == GreekMethod.ANALYTIC:
             greek = 0.0
-            direction = self._contract.get_direction()
+            spot = self._model.get_initial_spot()
             strike = self._contract.get_strike()
             tenor = self._contract.get_expiry()
             vol = self._model.get_volgrid().get_vol(tenor, spot / strike)
@@ -105,87 +155,57 @@ class EuropeanAnalyticPricer(Pricer):
                 greek = -norm.cdf(-d1)
             else:
                 self.__raise_incorrect_derivative_type_error()
-            return direction * greek
+            return self._contract.get_direction() * greek
         elif method == GreekMethod.BUMP:
-            bump_size = self.RELATIVE_BUMP_SIZE * spot
-            bumped_fair_values = list()
-            for b in (bump_size, -bump_size):
-                model = copy.deepcopy(self._model)
-                model.bump_initial_spot(b)
-                bumped_pricer = globals()[type(self).__name__](self._contract, model, self._method)
-                bumped_fair_values.append(bumped_pricer.calc_fair_value())
-                del bumped_pricer
-                del model
-            return (bumped_fair_values[0] - bumped_fair_values[1]) / (2 * bump_size)
+            return super().calc_delta(method)
         else:
             self._raise_unsupported_greek_method_error(method)
 
     def calc_gamma(self, method: GreekMethod) -> float:
-        spot = self._model.get_initial_spot()
         if method == GreekMethod.ANALYTIC:
             greek = 0.0
-            direction = self._contract.get_direction()
+            spot = self._model.get_initial_spot()
             strike = self._contract.get_strike()
             tenor = self._contract.get_expiry()
             vol = self._model.get_volgrid().get_vol(tenor, spot / strike)
             rate = self._model.get_rate()
+            d1 = EuropeanAnalyticPricer.__d1(spot, strike, vol, rate, tenor)
             if self._contract.get_type() in (PutCallFwd.CALL, PutCallFwd.PUT):
-                d1 = EuropeanAnalyticPricer.__d1(spot, strike, vol, rate, tenor)
                 greek = norm.pdf(d1) / (spot * vol * np.sqrt(tenor))
             else:
                 self.__raise_incorrect_derivative_type_error()
-            return direction * greek
+            return self._contract.get_direction() * greek
         elif method == GreekMethod.BUMP:
-            bump_size = self.RELATIVE_BUMP_SIZE * spot
-            bumped_fair_values = list()
-            for b in (bump_size, -bump_size):
-                model = copy.deepcopy(self._model)
-                model.bump_initial_spot(b)
-                bumped_pricer = globals()[type(self).__name__](self._contract, model, self._method)
-                bumped_fair_values.append(bumped_pricer.calc_fair_value())
-                del bumped_pricer
-                del model
-            return (bumped_fair_values[0] - 2 * self.calc_fair_value() + bumped_fair_values[1]) / (bump_size ** 2)
+            return super().calc_gamma(method)
         else:
             self._raise_unsupported_greek_method_error(method)
 
     def calc_vega(self, method: GreekMethod) -> float:
-        spot = self._model.get_initial_spot()
-        strike = self._contract.get_strike()
-        tenor = self._contract.get_expiry()
-        vol = self._model.get_volgrid().get_vol(tenor, spot / strike)
         if method == GreekMethod.ANALYTIC:
             greek = 0.0
-            direction = self._contract.get_direction()
+            spot = self._model.get_initial_spot()
+            strike = self._contract.get_strike()
+            tenor = self._contract.get_expiry()
+            vol = self._model.get_volgrid().get_vol(tenor, spot / strike)
             rate = self._model.get_rate()
             df = self._model.get_df(tenor)
+            d2 = EuropeanAnalyticPricer.__d2(spot, strike, vol, rate, tenor)
             if self._contract.get_type() in (PutCallFwd.CALL, PutCallFwd.PUT):
-                d2 = EuropeanAnalyticPricer.__d2(spot, strike, vol, rate, tenor)
                 greek = strike * df * norm.pdf(d2) * np.sqrt(tenor)
             else:
                 self.__raise_incorrect_derivative_type_error()
-            return direction * greek
+            return self._contract.get_direction() * greek
         elif method == GreekMethod.BUMP:
-            bump_size = self.RELATIVE_BUMP_SIZE * vol
-            bumped_fair_values = list()
-            for b in (bump_size, -bump_size):
-                model = copy.deepcopy(self._model)
-                model.bump_volgrid(b)
-                bumped_pricer = globals()[type(self).__name__](self._contract, model, self._method)
-                bumped_fair_values.append(bumped_pricer.calc_fair_value())
-                del bumped_pricer
-                del model
-            return (bumped_fair_values[0] - bumped_fair_values[1]) / (2 * bump_size)
+            return super().calc_vega(method)
         else:
             self._raise_unsupported_greek_method_error(method)
 
     def calc_theta(self, method: GreekMethod) -> float:
-        tenor = self._contract.get_expiry()
         if method == GreekMethod.ANALYTIC:
             greek = 0.0
-            direction = self._contract.get_direction()
             strike = self._contract.get_strike()
             spot = self._model.get_initial_spot()
+            tenor = self._contract.get_expiry()
             vol = self._model.get_volgrid().get_vol(tenor, spot / strike)
             rate = self._model.get_rate()
             df = self._model.get_df(tenor)
@@ -197,27 +217,20 @@ class EuropeanAnalyticPricer(Pricer):
                 greek = -1.0 * ((spot * norm.pdf(d1) * vol) / (2 * np.sqrt(tenor)) - rate * strike * df * norm.cdf(-d2))
             else:
                 self.__raise_incorrect_derivative_type_error()
-            return direction * greek
+            return self._contract.get_direction() * greek
         elif method == GreekMethod.BUMP:
-            bump_size = 1.0 / 252.0
-            contract = copy.deepcopy(self._contract)
-            contract.set_expiry(tenor + bump_size)
-            bumped_pricer = globals()[type(self).__name__](contract, self._model, self._method)
-            bumped_fair_value = bumped_pricer.calc_fair_value()
-            del bumped_pricer
-            return -1.0 * (bumped_fair_value - self.calc_fair_value()) / bump_size
+            return super().calc_theta(method)
         else:
             self._raise_unsupported_greek_method_error(method)
 
     def calc_rho(self, method: GreekMethod) -> float:
-        rate = self._model.get_rate()
         if method == GreekMethod.ANALYTIC:
             greek = 0.0
-            direction = self._contract.get_direction()
             strike = self._contract.get_strike()
             tenor = self._contract.get_expiry()
             spot = self._model.get_initial_spot()
             vol = self._model.get_volgrid().get_vol(tenor, spot / strike)
+            rate = self._model.get_rate()
             df = self._model.get_df(tenor)
             d2 = EuropeanAnalyticPricer.__d2(spot, strike, vol, rate, tenor)
             if self._contract.get_type() == PutCallFwd.CALL:
@@ -226,18 +239,9 @@ class EuropeanAnalyticPricer(Pricer):
                 greek = -strike * tenor * df * norm.cdf(-d2)
             else:
                 self.__raise_incorrect_derivative_type_error()
-            return direction * greek
+            return self._contract.get_direction() * greek
         elif method == GreekMethod.BUMP:
-            bump_size = self.RELATIVE_BUMP_SIZE * rate
-            bumped_fair_values = list()
-            for b in (bump_size, -bump_size):
-                model = copy.deepcopy(self._model)
-                model.bump_rate(b)
-                bumped_pricer = globals()[type(self).__name__](self._contract, model, self._method)
-                bumped_fair_values.append(bumped_pricer.calc_fair_value())
-                del bumped_pricer
-                del model
-            return (bumped_fair_values[0] - bumped_fair_values[1]) / (2 * bump_size)
+            return super().calc_rho(method)
         else:
             self._raise_unsupported_greek_method_error(method)
 

--- a/src/pricer.py
+++ b/src/pricer.py
@@ -7,6 +7,7 @@ from src.model import *
 from src.numerical_method import *
 from scipy.stats import norm
 
+
 class Pricer(ABC):
     RELATIVE_BUMP_SIZE: float = 0.01
 
@@ -105,12 +106,12 @@ class Pricer(ABC):
 
 class EuropeanAnalyticPricer(Pricer):
     @staticmethod
-    def __d1(spot: float, strike: float, vol: float, rate: float, tenor: float):
+    def d1(spot: float, strike: float, vol: float, rate: float, tenor: float):
         return 1 / (vol * np.sqrt(tenor)) * (np.log(spot / strike) + (rate + vol**2 / 2) * tenor)
 
     @staticmethod
-    def __d2(spot: float, strike: float, vol: float, rate: float, tenor: float):
-        d1 = EuropeanAnalyticPricer.__d1(spot, strike, vol, rate, tenor)
+    def d2(spot: float, strike: float, vol: float, rate: float, tenor: float):
+        d1 = EuropeanAnalyticPricer.d1(spot, strike, vol, rate, tenor)
         return d1 - vol * np.sqrt(tenor)
 
     def __init__(self, contract: EuropeanContract, model: MarketModel, method: AnalyticMethod):
@@ -130,8 +131,8 @@ class EuropeanAnalyticPricer(Pricer):
         vol = self._model.get_vol(tenor, spot / strike)
         rate = self._model.get_rate()
         df = self._model.get_df(tenor)
-        d1 = EuropeanAnalyticPricer.__d1(spot, strike, vol, rate, tenor)
-        d2 = EuropeanAnalyticPricer.__d2(spot, strike, vol, rate, tenor)
+        d1 = EuropeanAnalyticPricer.d1(spot, strike, vol, rate, tenor)
+        d2 = EuropeanAnalyticPricer.d2(spot, strike, vol, rate, tenor)
         if self._contract.get_type() == PutCallFwd.CALL:
             return direction * (spot * norm.cdf(d1) - strike * df * norm.cdf(d2))
         elif self._contract.get_type() == PutCallFwd.PUT:
@@ -147,7 +148,7 @@ class EuropeanAnalyticPricer(Pricer):
             tenor = self._contract.get_expiry()
             vol = self._model.get_volgrid().get_vol(tenor, spot / strike)
             rate = self._model.get_rate()
-            d1 = EuropeanAnalyticPricer.__d1(spot, strike, vol, rate, tenor)
+            d1 = EuropeanAnalyticPricer.d1(spot, strike, vol, rate, tenor)
             if self._contract.get_type() == PutCallFwd.CALL:
                 greek = norm.cdf(d1)
             elif self._contract.get_type() == PutCallFwd.PUT:
@@ -168,7 +169,7 @@ class EuropeanAnalyticPricer(Pricer):
             tenor = self._contract.get_expiry()
             vol = self._model.get_volgrid().get_vol(tenor, spot / strike)
             rate = self._model.get_rate()
-            d1 = EuropeanAnalyticPricer.__d1(spot, strike, vol, rate, tenor)
+            d1 = EuropeanAnalyticPricer.d1(spot, strike, vol, rate, tenor)
             if self._contract.get_type() in (PutCallFwd.CALL, PutCallFwd.PUT):
                 greek = norm.pdf(d1) / (spot * vol * np.sqrt(tenor))
             else:
@@ -188,7 +189,7 @@ class EuropeanAnalyticPricer(Pricer):
             vol = self._model.get_volgrid().get_vol(tenor, spot / strike)
             rate = self._model.get_rate()
             df = self._model.get_df(tenor)
-            d2 = EuropeanAnalyticPricer.__d2(spot, strike, vol, rate, tenor)
+            d2 = EuropeanAnalyticPricer.d2(spot, strike, vol, rate, tenor)
             if self._contract.get_type() in (PutCallFwd.CALL, PutCallFwd.PUT):
                 greek = strike * df * norm.pdf(d2) * np.sqrt(tenor)
             else:
@@ -208,8 +209,8 @@ class EuropeanAnalyticPricer(Pricer):
             vol = self._model.get_volgrid().get_vol(tenor, spot / strike)
             rate = self._model.get_rate()
             df = self._model.get_df(tenor)
-            d1 = EuropeanAnalyticPricer.__d1(spot, strike, vol, rate, tenor)
-            d2 = EuropeanAnalyticPricer.__d2(spot, strike, vol, rate, tenor)
+            d1 = EuropeanAnalyticPricer.d1(spot, strike, vol, rate, tenor)
+            d2 = EuropeanAnalyticPricer.d2(spot, strike, vol, rate, tenor)
             if self._contract.get_type() == PutCallFwd.CALL:
                 greek = -1.0 * ((spot * norm.pdf(d1) * vol) / (2 * np.sqrt(tenor)) + rate * strike * df * norm.cdf(d2))
             elif self._contract.get_type() == PutCallFwd.PUT:
@@ -231,7 +232,7 @@ class EuropeanAnalyticPricer(Pricer):
             vol = self._model.get_volgrid().get_vol(tenor, spot / strike)
             rate = self._model.get_rate()
             df = self._model.get_df(tenor)
-            d2 = EuropeanAnalyticPricer.__d2(spot, strike, vol, rate, tenor)
+            d2 = EuropeanAnalyticPricer.d2(spot, strike, vol, rate, tenor)
             if self._contract.get_type() == PutCallFwd.CALL:
                 greek = strike * tenor * df * norm.cdf(d2)
             elif self._contract.get_type() == PutCallFwd.PUT:
@@ -290,11 +291,14 @@ class GenericTreePricer(Pricer):
     def calc_rho(self, method: GreekMethod) -> float:
         raise NotImplementedError('Greeks are not implemented for tree method yet.')
 
+
 # todo: to be implemented
 class GenericPDEPricer(Pricer):
-    pass
+    def calc_fair_value(self) -> float:
+        raise NotImplementedError('Fair value is not implemented yet for GenericPDEPricer.')
 
 
 # todo: to be implemented
 class GenericMCPricer(Pricer):
-    pass
+    def calc_fair_value(self) -> float:
+        raise NotImplementedError('Fair value is not implemented yet for GenericMCPricer.')


### PR DESCRIPTION
Delta, gamma and theta can be significantly different between analytic and bump methods in FlatVolModel. The reason behind it is that by shocking the spot or remaining time to maturity, a different volatility is taken from the unshocked volgrid. For delta and gamma, this is sticky strike vs. sticky moneyness behaviour.

There is no plan to introduce different stickyness, and the code would be much more complex if it was handled properly.