### PR TITLE
Refactor contract classes and payoff functions to take dict as input

### DIFF
--- a/src/contract.py
+++ b/src/contract.py
@@ -1,29 +1,31 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
-
-import numpy as np
 from src.enums import *
 from statistics import mean
+import numpy as np
 
 
 class Contract(ABC):
-    def __init__(self, und: Stock, dtype: PutCallFwd, longshort: LongShort,
+    TIMELINE_DIGITS: int = 6
+
+    def __init__(self, und: Stock, dtype: PutCallFwd, long_short: LongShort,
                  strk: float, exp: float, num_mon: int = 1) -> None:
         self._underlying: Stock = und
         self._derivative_type: PutCallFwd = dtype
-        self._derivative_longshort: LongShort = longshort
-        self._direction: float = 1.0 if self._derivative_longshort == LongShort.LONG else -1.0
+        self._long_short: LongShort = long_short
+        self._direction: float = 1.0 if self._long_short == LongShort.LONG else -1.0
         self._strike: float = strk
         self._expiry: float = exp
-        self._num_mon: int = num_mon    # Asian: nr of averaging points; Barrier: nr of monitoring points
+        self._num_mon: int = round(max(num_mon, 1))  # Asian: nr of averaging points; Barrier: nr of monitoring points
+        self._contract_type: str = type(self).get_contract_type_static()
 
-        if self.__class__.__name__ != 'Contract':
-            self._contract = self.__class__.__name__.replace('Contract', '')
-        else:
-            self._contract = self.__class__.__name__
+    @classmethod
+    def get_contract_type_static(cls):
+        name = cls.__name__
+        return name if name == Contract.__name__ else name.removesuffix('Contract')
 
-    def get_contract(self) -> str:
-        return self._contract
+    def get_contract_type(self) -> str:
+        return self._contract_type
 
     def get_und(self) -> Stock:
         return self._underlying
@@ -31,8 +33,8 @@ class Contract(ABC):
     def get_type(self) -> PutCallFwd:
         return self._derivative_type
 
-    def get_longshort(self) -> LongShort:
-        return self._derivative_longshort
+    def get_long_short(self) -> LongShort:
+        return self._long_short
 
     def get_direction(self) -> float:
         return self._direction
@@ -49,15 +51,15 @@ class Contract(ABC):
     def __str__(self) -> str:
         return str(self.to_dict())
 
-    @abstractmethod
     def to_dict(self) -> dict[str, any]:
         return {
-            "contract": self._contract,
+            "contract": self._contract_type,
             "underlying": self._underlying,
             "type": self._derivative_type,
-            "longshort": self._derivative_longshort,
+            "long_short": self._long_short,
             "strike": self._strike,
-            "expiry": self._expiry
+            "expiry": self._expiry,
+            "observations": self._num_mon
         }
 
     @abstractmethod
@@ -68,324 +70,269 @@ class Contract(ABC):
     def get_timeline(self) -> list[float]:
         pass
 
+    @abstractmethod
+    def payoff(self, spot: dict[float, float]) -> float:
+        pass
+
     def raise_incorrect_derivative_type_error(
             self,
-            supported: tuple[PutCallFwd] = (PutCallFwd.CALL, PutCallFwd.PUT)) -> None:
+            supported: tuple[PutCallFwd, ...] = (PutCallFwd.CALL, PutCallFwd.PUT)) -> None:
         raise ValueError(f'Derivative type of {type(self).__name__} must be one of '
                          f'{", ".join(supported)}, but received {self.get_type()}')
 
+    def _raise_missing_spot_error(self, received: list[float]):
+        raise ValueError(f'{type(self).__name__} expects spot price on timeline {self.get_timeline()}, '
+                         f'but received on {received}')
 
-class VanillaContract(Contract):
-    def to_dict(self) -> dict[str, any]:
-        return super().to_dict()
 
-    @abstractmethod
+class ForwardContract(Contract):
+    def __init__(self, und: Stock, long_short: LongShort, strk: float, exp: float) -> None:
+        super().__init__(und, PutCallFwd.FWD, long_short, strk, exp)
+
     def convert_to_generic(self) -> GenericContract:
-        pass
-
-    @abstractmethod
-    def payoff(self, spot: float) -> float:
-        pass
+        return GenericContract(self._contract_type, self._underlying, self._derivative_type, self._long_short,
+                               self._strike, self._expiry)
 
     def get_timeline(self) -> list[float]:
-        return [self._expiry]
+        return [round(self._expiry, self.TIMELINE_DIGITS)]
+
+    def payoff(self, spot: dict[float, float]) -> float:
+        t = self.get_timeline()[0]
+        if t not in spot.keys():
+            self._raise_missing_spot_error(list(spot.keys()))
+        return self._direction * (spot[t] - self._strike)
 
 
-class ForwardContract(VanillaContract):
-    def __init__(self, und: Stock, longshort: LongShort, strk: float, exp: float) -> None:
-        super().__init__(und, PutCallFwd.FWD, longshort, strk, exp)
-
-    def convert_to_generic(self) -> GenericContract:
-        return GenericContract(self._contract, self._underlying, self._derivative_type,
-                               self._derivative_longshort, self._strike, self._expiry)
-
-    def payoff(self, spot: float) -> float:
-        return self._direction * (spot - self._strike)
-
-
-class EuropeanContract(VanillaContract):
-    def __init__(self, und: Stock, dtype: PutCallFwd, longshort: LongShort, strk: float, exp: float) -> None:
+class EuropeanContract(Contract):
+    def __init__(self, und: Stock, dtype: PutCallFwd, long_short: LongShort, strk: float, exp: float) -> None:
         if dtype not in [PutCallFwd.CALL, PutCallFwd.PUT]:
             self.raise_incorrect_derivative_type_error()
-        super().__init__(und, dtype, longshort, strk, exp)
+        super().__init__(und, dtype, long_short, strk, exp)
 
     def convert_to_generic(self) -> GenericContract:
-        return GenericContract(self._contract, self._underlying, self._derivative_type,
-                               self._derivative_longshort, self._strike, self._expiry)
-
-    def payoff(self, spot: float) -> float:
-        if self._derivative_type == PutCallFwd.CALL:
-            return self._direction * max(spot - self._strike, 0)
-        elif self._derivative_type == PutCallFwd.PUT:
-            return self._direction * max(self._strike - spot, 0)
-        else:
-            self.raise_incorrect_derivative_type_error()
-
-
-class AmericanContract(VanillaContract):
-    def __init__(self, und: Stock, dtype: PutCallFwd, longshort: LongShort, strk: float, exp: float) -> None:
-        if dtype not in [PutCallFwd.CALL, PutCallFwd.PUT]:
-            self.raise_incorrect_derivative_type_error()
-        super().__init__(und, dtype, longshort, strk, exp)
-
-    def convert_to_generic(self) -> GenericContract:
-        return GenericContract(self._contract, self._underlying, self._derivative_type,
-                               self._derivative_longshort, self._strike, self._expiry)
-
-    def payoff(self, spot: float) -> float:
-        if self._derivative_type == PutCallFwd.CALL:
-            return self._direction * max(spot - self._strike, 0)
-        elif self._derivative_type == PutCallFwd.PUT:
-            return self._direction * max(self._strike - spot, 0)
-        else:
-            self.raise_incorrect_derivative_type_error()
-
-
-class EuropeanDigitalContract(VanillaContract):
-    def __init__(self, und: Stock, dtype: PutCallFwd, longshort: LongShort, strk: float, exp: float) -> None:
-        if dtype not in [PutCallFwd.CALL, PutCallFwd.PUT]:
-            self.raise_incorrect_derivative_type_error()
-        super().__init__(und, dtype, longshort, strk, exp)
-
-    def convert_to_generic(self) -> GenericContract:
-        return GenericContract(self._contract, self._underlying, self._derivative_type,
-                               self._derivative_longshort, self._strike, self._expiry)
-
-    def payoff(self, spot: float) -> float:
-        if self._derivative_type == PutCallFwd.CALL:
-            return self._direction * float(spot - self._strike > 0)
-        elif self._derivative_type == PutCallFwd.PUT:
-            return self._direction * float(self._strike - spot > 0)
-        else:
-            self.raise_incorrect_derivative_type_error()
-
-
-class ExoticContract(Contract):
-    def to_dict(self) -> dict[str, any]:
-        return super().to_dict()
-
-    @abstractmethod
-    def convert_to_generic(self) -> GenericContract:
-        pass
-
-    @abstractmethod
-    def payoff(self, spot: float) -> float:
-        pass
+        return GenericContract(self._contract_type, self._underlying, self._derivative_type, self._long_short,
+                               self._strike, self._expiry)
 
     def get_timeline(self) -> list[float]:
-        return [((i+1)/self._num_mon)*self._expiry for i in range(self._num_mon)]
+        return [round(self._expiry, self.TIMELINE_DIGITS)]
 
-    def _raise_incorrect_barrier_updown_type(self):
-        raise TypeError(f'Updown parameter of {type(self).__name__} must be UP or DOWN')
-
-    def _raise_incorrect_barrier_inout_type(self):
-        raise TypeError(f'Inout parameter of {type(self).__name__} must be IN or OUT')
-
-
-class AsianContract(ExoticContract):
-    def __init__(self, und: Stock, dtype: PutCallFwd, longshort: LongShort, strk: float, exp: float) -> None:
-        if dtype not in [PutCallFwd.CALL, PutCallFwd.PUT]:
-            self.raise_incorrect_derivative_type_error()
-        super().__init__(und, dtype, longshort, strk, exp)
-
-    def convert_to_generic(self) -> GenericContract:
-        return GenericContract(self._contract, self._underlying, self._derivative_type,
-                               self._derivative_longshort, self._strike, self._expiry)
-
-    def payoff(self, prices_und: float) -> float:
-    # todo: prices_und to derive from the underlying process using the timeline
+    def payoff(self, spot: dict[float, float]) -> float:
+        t = self.get_timeline()[0]
+        if t not in spot.keys():
+            self._raise_missing_spot_error(list(spot.keys()))
         if self._derivative_type == PutCallFwd.CALL:
-            return self._direction * max(mean(prices_und) - self._strike, 0)
+            return self._direction * max(spot[t] - self._strike, 0)
         elif self._derivative_type == PutCallFwd.PUT:
-            return self._direction * max(self._strike - mean(prices_und), 0)
+            return self._direction * max(self._strike - spot[t], 0)
         else:
             self.raise_incorrect_derivative_type_error()
 
 
-class EuropeanBarrierContract(ExoticContract):
-    def __init__(self, und: Stock, dtype: PutCallFwd, longshort: LongShort, strk: float, exp: float,
-                 barrier: float, updown: UpDown, inout: InOut) -> None:
+class AmericanContract(Contract):
+    def __init__(self, und: Stock, dtype: PutCallFwd, long_short: LongShort, strk: float, exp: float) -> None:
         if dtype not in [PutCallFwd.CALL, PutCallFwd.PUT]:
             self.raise_incorrect_derivative_type_error()
-        if updown not in [UpDown.UP, UpDown.DOWN]:
-            self._raise_incorrect_barrier_updown_type()
-        if inout not in [InOut.IN, InOut.OUT]:
-            self._raise_incorrect_barrier_inout_type()
-        super().__init__(und, dtype, longshort, strk, exp)
-        self._barrier = barrier
-        self._updown = updown
-        self._inout = inout
-        self.misc_barrier = Barrier(self._barrier, self._updown, self._inout)
-        self.get_barrier = self.misc_barrier.get_barrier
-        self.get_updown = self.misc_barrier.get_updown
-        self.get_inout = self.misc_barrier.get_inout
-
-    def is_breached(self, prices_und) -> bool:
-        return self.misc_barrier.is_breached(prices_und)
+        super().__init__(und, dtype, long_short, strk, exp)
 
     def convert_to_generic(self) -> GenericContract:
-        return GenericContract(self._contract, self._underlying, self._derivative_type,
-                               self._derivative_longshort, self._strike, self._expiry,
-                               self._barrier, self._updown, self._inout)
+        return GenericContract(self._contract_type, self._underlying, self._derivative_type, self._long_short,
+                               self._strike, self._expiry)
+
+    def get_timeline(self) -> list[float]:
+        return [round(self._expiry, self.TIMELINE_DIGITS)]
+
+    def payoff(self, spot: dict[float, float]) -> float:
+        t = self.get_timeline()[0]
+        if t not in spot.keys():
+            self._raise_missing_spot_error(list(spot.keys()))
+        if self._derivative_type == PutCallFwd.CALL:
+            return self._direction * max(spot[t] - self._strike, 0)
+        elif self._derivative_type == PutCallFwd.PUT:
+            return self._direction * max(self._strike - spot[t], 0)
+        else:
+            self.raise_incorrect_derivative_type_error()
+
+
+class EuropeanDigitalContract(Contract):
+    def __init__(self, und: Stock, dtype: PutCallFwd, long_short: LongShort, strk: float, exp: float) -> None:
+        if dtype not in [PutCallFwd.CALL, PutCallFwd.PUT]:
+            self.raise_incorrect_derivative_type_error()
+        super().__init__(und, dtype, long_short, strk, exp)
+
+    def convert_to_generic(self) -> GenericContract:
+        return GenericContract(self._contract_type, self._underlying, self._derivative_type, self._long_short,
+                               self._strike, self._expiry)
+
+    def get_timeline(self) -> list[float]:
+        return [round(self._expiry, self.TIMELINE_DIGITS)]
+
+    def payoff(self, spot: dict[float, float]) -> float:
+        t = self.get_timeline()[0]
+        if t not in spot.keys():
+            self._raise_missing_spot_error(list(spot.keys()))
+        if self._derivative_type == PutCallFwd.CALL:
+            return self._direction * float(spot[t] - self._strike > 0)
+        elif self._derivative_type == PutCallFwd.PUT:
+            return self._direction * float(self._strike - spot[t] > 0)
+        else:
+            self.raise_incorrect_derivative_type_error()
+
+
+class AsianContract(Contract):
+    def __init__(self, und: Stock, dtype: PutCallFwd, long_short: LongShort, strk: float, exp: float,
+                 num_mon: int) -> None:
+        if dtype not in [PutCallFwd.CALL, PutCallFwd.PUT]:
+            self.raise_incorrect_derivative_type_error()
+        super().__init__(und, dtype, long_short, strk, exp, num_mon)
+
+    def convert_to_generic(self) -> GenericContract:
+        return GenericContract(self._contract_type, self._underlying, self._derivative_type, self._long_short,
+                               self._strike, self._expiry, self._num_mon)
+
+    def get_timeline(self) -> list[float]:
+        return [round(((i+1) / self._num_mon) * self._expiry, self.TIMELINE_DIGITS) for i in range(self._num_mon)]
+
+    def payoff(self, spot: dict[float, float]) -> float:
+        timeline = self.get_timeline()
+        if not set(timeline).issubset(set(spot.keys())):
+            self._raise_missing_spot_error(list(spot.keys()))
+        obs = [spot[t] for t in timeline]
+        if self._derivative_type == PutCallFwd.CALL:
+            return self._direction * max(mean(obs) - self._strike, 0)
+        elif self._derivative_type == PutCallFwd.PUT:
+            return self._direction * max(self._strike - mean(obs), 0)
+        else:
+            self.raise_incorrect_derivative_type_error()
+
+
+class EuropeanBarrierContract(Contract):
+    def __init__(self, und: Stock, dtype: PutCallFwd, long_short: LongShort, strk: float, exp: float,
+                 num_mon: int, barrier: float, up_down: UpDown, in_out: InOut) -> None:
+        if dtype not in [PutCallFwd.CALL, PutCallFwd.PUT]:
+            self.raise_incorrect_derivative_type_error()
+        super().__init__(und, dtype, long_short, strk, exp, num_mon)
+        self._barrier: Barrier = Barrier(barrier, up_down, in_out)
+
+    def get_barrier(self) -> Barrier:
+        return self._barrier
 
     def to_dict(self) -> dict[str, any]:
         out = super().to_dict()
-        out |= {"barrier": self._barrier, "updown": self._updown, "inout": self._inout}
+        out |= {
+            'barrier': self._barrier.get_barrier_level(),
+            'up_down': self._barrier.get_up_down(),
+            'in_out': self._barrier.get_in_out()
+        }
         return out
 
-    def payoff(self, prices_und: float) -> float:
-    # todo: prices_und to derive from the underlying process using the timeline
-        mult = (self._inout == 'IN') * self.is_breached(prices_und) + \
-               (self._inout == 'OUT') * (1 - self.is_breached(prices_und))
+    def convert_to_generic(self) -> GenericContract:
+        return GenericContract(self._contract_type, self._underlying, self._derivative_type, self._long_short,
+                               self._strike, self._expiry, self._num_mon, self._barrier.get_barrier_level(),
+                               self._barrier.get_up_down(), self._barrier.get_in_out())
 
+    def get_timeline(self) -> list[float]:
+        return [round(((i+1) / self._num_mon) * self._expiry, self.TIMELINE_DIGITS) for i in range(self._num_mon)]
+
+    def payoff(self, spot: dict[float, float]) -> float:
+        timeline = self.get_timeline()
+        if not set(timeline).issubset(set(spot.keys())):
+            self._raise_missing_spot_error(list(spot.keys()))
+        obs = [spot[t] for t in timeline]
+        in_out = self._barrier.get_in_out()
+        is_breached = int(self._barrier.is_breached(obs))
+        mult = float(int(in_out == InOut.IN) * is_breached + int(in_out == InOut.OUT) * (1 - is_breached))
         if self._derivative_type == PutCallFwd.CALL:
-            return mult * self._direction * max(prices_und[-1] - self._strike, 0)
+            return self._direction * mult * max(obs[-1] - self._strike, 0)
         elif self._derivative_type == PutCallFwd.PUT:
-            return mult * self._direction * max(self._strike - prices_und[-1], 0)
+            return self._direction * mult * max(self._strike - obs[-1], 0)
         else:
             self.raise_incorrect_derivative_type_error()
 
 
-class GenericContract(ExoticContract):
-    def __init__(self, contract: str, und: Stock, dtype: PutCallFwd, longshort: LongShort, strk: float, exp: float,
-                 barrier: float = np.Inf, updown: UpDown = None, inout: InOut = None) -> None:
+class GenericContract(Contract):
+    def __init__(self, contract_type: str, und: Stock, dtype: PutCallFwd, long_short: LongShort, strk: float,
+                 exp: float, num_mon: int = 1, barrier: float = np.nan, up_down: UpDown | None = None,
+                 in_out: InOut | None = None) -> None:
         supported_deriv_types = (PutCallFwd.CALL, PutCallFwd.PUT, PutCallFwd.FWD)
         if dtype not in supported_deriv_types:
             self.raise_incorrect_derivative_type_error(supported_deriv_types)
-        if updown not in [UpDown.UP, UpDown.DOWN, None]:
-            self._raise_incorrect_barrier_updown_type()
-        if inout not in [InOut.IN, InOut.OUT, None]:
-            self._raise_incorrect_barrier_inout_type()
-        super().__init__(und, dtype, longshort, strk, exp)
-        self._contract = contract
-        self._barrier = barrier
-        self._updown = updown
-        self._inout = inout
-        self.misc_barrier = Barrier(self._barrier, self._updown, self._inout)
-        self.get_barrier = self.misc_barrier.get_barrier
-        self.get_updown = self.misc_barrier.get_updown
-        self.get_inout = self.misc_barrier.get_inout
+        super().__init__(und, dtype, long_short, strk, exp, num_mon)
+        self._contract_type: str = contract_type
+        self._barrier: Barrier | None = None
+        if barrier != np.nan and up_down is not None and in_out is not None:
+            self._barrier = Barrier(barrier, up_down, in_out)
 
-    def get_contract_type(self) -> str:
-        return self._contract
-
-    def is_breached(self, prices_und) -> bool:
-        return self.misc_barrier.is_breached(prices_und)
+    def get_barrier(self) -> Barrier | None:
+        return self._barrier
 
     def to_dict(self) -> dict[str, any]:
         out = super().to_dict()
-        out |= {"barrier": self._barrier, "updown": self._updown, "inout": self._inout}
+        if self._barrier is not None:
+            out |= {
+                'barrier': self._barrier.get_barrier_level(),
+                'up_down': self._barrier.get_up_down(),
+                'in_out': self._barrier.get_in_out()
+            }
         return out
 
     def convert_to_generic(self) -> GenericContract:
         return self
 
-    def payoff(self, prices_und: float) -> float:
-    # todo: prices_und to derive from the underlying process using the timeline
-        if self._contract == 'Forward':
-            return self._direction * (prices_und - self._strike)
+    def get_timeline(self) -> list[float]:
+        return [round(((i+1) / self._num_mon) * self._expiry, self.TIMELINE_DIGITS) for i in range(self._num_mon)]
 
-        elif self._contract == 'American' or self._contract == 'European':
-            if self._derivative_type == PutCallFwd.CALL:
-                return self._direction * max(prices_und - self._strike, 0)
-            elif self._derivative_type == PutCallFwd.PUT:
-                return self._direction * max(self._strike - prices_und, 0)
-
-        elif self._contract == 'EuropeanDigital':
-            if self._derivative_type == PutCallFwd.CALL:
-                return self._direction * float(prices_und - self._strike > 0)
-            elif self._derivative_type == PutCallFwd.PUT:
-                return self._direction * float(self._strike - prices_und > 0)
-
-        elif self._contract == 'Asian':
-            if self._derivative_type == PutCallFwd.CALL:
-                return self._direction * max(mean(prices_und) - self._strike, 0)
-            elif self._derivative_type == PutCallFwd.PUT:
-                return self._direction * max(self._strike - mean(prices_und), 0)
-
-        elif self._contract == 'EuropeanBarrier':
-            mult = (self._inout == 'IN') * self.is_breached(prices_und) + \
-                   (self._inout == 'OUT') * (1 - self.is_breached(prices_und))
-            if self._derivative_type == PutCallFwd.CALL:
-                return mult * self._direction * max(prices_und[-1] - self._strike, 0)
-            elif self._derivative_type == PutCallFwd.PUT:
-                return mult * self._direction * max(self._strike - prices_und[-1], 0)
+    def payoff(self, spot: dict[float, float]) -> float:
+        timeline = self.get_timeline()
+        if not set(timeline).issubset(set(spot.keys())):
+            self._raise_missing_spot_error(list(spot.keys()))
+        obs = [spot[t] for t in timeline]
+        payoff = mean(obs) - self._strike
+        call_put = 1.0 if self._derivative_type == PutCallFwd.CALL else -1.0
+        if self._contract_type == ForwardContract.get_contract_type_static():
+            return self._direction * payoff
+        elif self._contract_type == EuropeanDigitalContract.get_contract_type_static():
+            return self._direction * float(call_put * payoff > 0)
+        elif self._contract_type == EuropeanBarrierContract.get_contract_type_static():
+            mult = 1.0
+            if self._barrier is not None:
+                in_out = self._barrier.get_in_out()
+                is_breached = int(self._barrier.is_breached(obs))
+                mult = float(int(in_out == InOut.IN) * is_breached + int(in_out == InOut.OUT) * (1 - is_breached))
+            payoff = (obs[-1] - self._strike)
+            return self._direction * mult * max(call_put * payoff, 0)
+        else:
+            return self._direction * max(call_put * payoff, 0)
 
 
 class Barrier:
-    def __init__(self, barrier: float, updown: UpDown, inout: InOut) -> None:
-        self._barrier = barrier
-        self._updown = updown
-        self._inout = inout
+    def __init__(self, barrier_level: float, up_down: UpDown, in_out: InOut) -> None:
+        self._barrier_level: float = barrier_level
+        if up_down not in [UpDown.UP, UpDown.DOWN]:
+            self._raise_incorrect_up_down_type()
+        self._up_down: UpDown = up_down
+        if in_out not in [InOut.IN, in_out.OUT]:
+            self._raise_incorrect_in_out_type()
+        self._in_out: InOut = in_out
 
-    def get_barrier(self) -> float:
-        return self._barrier
+    def get_barrier_level(self) -> float:
+        return self._barrier_level
 
-    def get_updown(self) -> UpDown:
-        return self._updown
+    def get_up_down(self) -> UpDown:
+        return self._up_down
 
-    def get_inout(self) -> InOut:
-        return self._inout
+    def get_in_out(self) -> InOut:
+        return self._in_out
 
-    def is_breached(self, prices_und) -> bool:
-        if self._updown == 'UP':
-            return any(self._barrier <= price for price in prices_und)
+    def is_breached(self, observations: list[float]) -> bool:
+        if self._up_down == UpDown.UP:
+            return any([self._barrier_level <= price for price in observations])
+        elif self._up_down == UpDown.DOWN:
+            return any([self._barrier_level >= price for price in observations])
         else:
-            return any(self._barrier >= price for price in prices_und)
+            self._raise_incorrect_up_down_type()
 
+    def _raise_incorrect_up_down_type(self):
+        raise TypeError(f'Updown parameter of {type(self).__name__} must be UP or DOWN')
 
-def main():
-
-    values = [-1, -0.5, 0, 0.5, 1, 1.5, 2, 2.5, 3]
-
-    trade1 = ForwardContract('Apple', 'SHORT', 1, 2)
-    print(trade1)
-    print([trade1.payoff(value) for value in values])
-    print(trade1.get_contract())
-
-    generic_trade1 = trade1.convert_to_generic()
-    print(generic_trade1)
-    print([generic_trade1.payoff(value) for value in values])
-
-    trade2 = EuropeanContract('OTP', 'CALL', 'LONG', 1, 2)
-    print(trade2)
-    print([trade2.payoff(value) for value in values])
-    generic_trade2 = trade2.convert_to_generic()
-    print(generic_trade2)
-    print([generic_trade2.payoff(value) for value in values])
-
-    trade3 = AmericanContract('Tesla', 'CALL', 'LONG', 1, 2)
-    print(trade3)
-    print([trade3.payoff(value) for value in values])
-    generic_trade3 = trade3.convert_to_generic()
-    print(generic_trade3)
-    print([generic_trade3.payoff(value) for value in values])
-
-    trade4 = EuropeanDigitalContract('Mol', 'CALL', 'LONG', 1, 2)
-    print(trade4)
-    print([trade4.payoff(value) for value in values])
-    generic_trade4 = trade4.convert_to_generic()
-    print(generic_trade4)
-    print([generic_trade4.payoff(value) for value in values])
-
-    trade5 = AsianContract('Microsoft', 'CALL', 'LONG', 0.8, 2)
-    print(trade5)
-    print(trade5.payoff(values))
-    generic_trade5 = trade5.convert_to_generic()
-    print(generic_trade5)
-    print(generic_trade5.payoff(values))
-
-    trade6 = EuropeanBarrierContract('Deutshe Bank', 'CALL', 'LONG', 1.5, 2, 2.7, "UP", "IN")
-    print(trade6)
-    print(trade6.is_breached([1, 2, 2.5, 2]),
-          trade6.is_breached([1, 2, 3.5, 2]) )
-    print(trade6.payoff(values))
-    generic_trade6 = trade6.convert_to_generic()
-    print(generic_trade6)
-    print(generic_trade6.is_breached([1, 2, 2.5, 2]),
-          generic_trade6.is_breached([1, 2, 3.5, 2]) )
-    print(generic_trade6.payoff(values))
-
-
-if __name__ == '__main__':
-    main()
+    def _raise_incorrect_in_out_type(self):
+        raise TypeError(f'Inout parameter of {type(self).__name__} must be IN or OUT')

--- a/src/numerical_method.py
+++ b/src/numerical_method.py
@@ -80,7 +80,7 @@ class SimpleBinomialTree(NumericalMethod):
 
 
 class BalancedSimpleBinomialTree(SimpleBinomialTree):
-    def __init__(self, params: TreeParams, model: FlatVolModel):
+    def __init__(self, params: TreeParams, model: MarketModel):
         up = BalancedSimpleBinomialTree.calc_up_step_mult(
             model.get_rate(),
             model.get_vol(params.strike, params.exp),

--- a/src/pricer.py
+++ b/src/pricer.py
@@ -325,7 +325,7 @@ class EuropeanAnalyticPricer(Pricer):
 
 
 class GenericTreePricer(Pricer):
-    def __init__(self, contract: VanillaContract, model: FlatVolModel, params: TreeParams):
+    def __init__(self, contract: Contract, model: MarketModel, params: TreeParams):
         self._contract = contract
         self._model = model
         self._params = params
@@ -341,11 +341,11 @@ class GenericTreePricer(Pricer):
         price_tree = [[np.nan for _ in level] for level in spot_tree]
         for i in range(len(spot_tree[-1])):
             log_spot = spot_tree[-1][i]
-            discounted_price = self._tree_method._df[-1] * self._contract.payoff(np.exp(log_spot))
+            spot = {self._contract.get_timeline()[0]: np.exp(log_spot)}
+            discounted_price = self._tree_method._df[-1] * self._contract.payoff(spot)
             price_tree[-1][i] = discounted_price
         for step in range(self._params.nr_steps - 1, -1, -1):
             for i in range(len(spot_tree[step])):
-                log_spot = spot_tree[step][i]
                 # discounted price is martingale
                 discounted_price = self._tree_method._prob[0] * price_tree[step + 1][i] + \
                                    self._tree_method._prob[1] * price_tree[step + 1][i + 1]

--- a/test/test_contract.py
+++ b/test/test_contract.py
@@ -1,107 +1,137 @@
-import os, sys
-sys.path.append(os.path.join(os.path.dirname(__file__),".."))
-sys.path.append(os.path.join(os.path.join(os.path.dirname(__file__),".."),'src'))
-
-import numpy as np
 import pytest
+import numpy as np
 from src.contract import *
 from src.enums import *
+from src.market_data import *
+
+MarketData.initialize()
 
 
 class TestContractProperties:
     underlying = Stock.EXAMPLE1
     derivative_type = PutCallFwd.CALL
-    longshort = LongShort.LONG
-    strike = 1.0
+    long_short = LongShort.LONG
+    ref_spot = MarketData.get_initial_spot()[underlying]
+    strike = 1.0 * ref_spot
     expiry = 1.0
 
-    @pytest.mark.parametrize('contract_property', ['underlying', 'type', 'longshort', 'strike', 'expiry'])
+    @pytest.mark.parametrize('contract_property',
+                             ['underlying', 'type', 'long_short', 'strike', 'expiry', 'observations'])
     def test_contract_to_dict(self, contract_property):
         contract_param_map = {
-            'ForwardContract': [self.underlying, self.longshort, self.strike, self.expiry],
-            'EuropeanContract': [self.underlying, self.derivative_type, self.longshort, self.strike, self.expiry],
-            'AmericanContract': [self.underlying, self.derivative_type, self.longshort, self.strike, self.expiry],
-            'EuropeanDigitalContract': [self.underlying, self.derivative_type, self.longshort, self.strike, self.expiry],
+            'ForwardContract': [self.underlying, self.long_short, self.strike, self.expiry],
+            'EuropeanContract': [self.underlying, self.derivative_type, self.long_short, self.strike, self.expiry],
+            'AmericanContract': [self.underlying, self.derivative_type, self.long_short, self.strike, self.expiry],
+            'EuropeanDigitalContract': [self.underlying, self.derivative_type, self.long_short, self.strike,
+                                        self.expiry],
+            'EuropeanBarrierContract': [self.underlying, self.derivative_type, self.long_short, self.strike,
+                                        12, self.expiry, 1.05 * self.ref_spot, UpDown.UP, InOut.OUT],
+            'AsianContract': [self.underlying, self.derivative_type, self.long_short, self.strike, self.expiry, 12],
         }
         for class_name, params in contract_param_map.items():
             contract = globals()[class_name](*params)
             assert contract_property in contract.to_dict().keys()
 
 
-@pytest.mark.parametrize('spot', np.arange(0, 2, 0.25))
-@pytest.mark.parametrize('strike', np.arange(0, 2, 0.25))
+@pytest.mark.parametrize('spot', np.arange(0.5, 2, 0.5))
+@pytest.mark.parametrize('strike', np.arange(0.5, 2, 0.5))
 class TestPayoff:
     underlying = Stock.EXAMPLE1
-    longshort = LongShort.LONG
+    ref_spot = MarketData.get_initial_spot()[underlying]
+    long_short = LongShort.LONG
     expiry = 1.0
 
     def test_forward_payoff(self, spot, strike):
-        contract = ForwardContract(self.underlying, self.longshort, strike, self.expiry)
-        assert contract.payoff(spot) == pytest.approx(spot - strike)
+        spot = spot * self.ref_spot
+        strike = strike * self.ref_spot
+        contract = ForwardContract(self.underlying, self.long_short, strike, self.expiry)
+        obs = {round(self.expiry, contract.TIMELINE_DIGITS): spot}
+        assert contract.payoff(obs) == pytest.approx(spot - strike)
 
     def test_call_payoff(self, spot, strike):
-        contract = EuropeanContract(self.underlying, PutCallFwd.CALL, self.longshort, strike, self.expiry)
-        assert contract.payoff(spot) == pytest.approx(max(spot - strike, 0))
+        spot = spot * self.ref_spot
+        strike = strike * self.ref_spot
+        contract = EuropeanContract(self.underlying, PutCallFwd.CALL, self.long_short, strike, self.expiry)
+        obs = {round(self.expiry, contract.TIMELINE_DIGITS): spot}
+        assert contract.payoff(obs) == pytest.approx(max(spot - strike, 0))
 
     def test_put_payoff(self, spot, strike):
-        contract = EuropeanContract(self.underlying, PutCallFwd.PUT, self.longshort, strike, self.expiry)
-        assert contract.payoff(spot) == pytest.approx(max(strike - spot, 0))
+        spot = spot * self.ref_spot
+        strike = strike * self.ref_spot
+        contract = EuropeanContract(self.underlying, PutCallFwd.PUT, self.long_short, strike, self.expiry)
+        obs = {round(self.expiry, contract.TIMELINE_DIGITS): spot}
+        assert contract.payoff(obs) == pytest.approx(max(strike - spot, 0))
 
 
-@pytest.mark.parametrize('spot', np.arange(-1, 3, 0.5))
-@pytest.mark.parametrize('strike', np.arange(-1, 3, 0.5))
-@pytest.mark.parametrize('longshort', [LongShort.LONG, LongShort.SHORT])
-class TestGenericPayoff_Fwd:
-    expiry = 2
-
-    def test_forward_payoff(self, longshort, spot, strike):
-        trade = ForwardContract('Apple', longshort, strike, self.expiry)
-        generic_trade = trade.convert_to_generic()
-        assert trade.payoff(spot) == pytest.approx(generic_trade.payoff(spot))
-
-
-@pytest.mark.parametrize('spot', np.arange(-1, 3, 0.5))
-@pytest.mark.parametrize('strike', np.arange(-1, 3, 0.5))
-@pytest.mark.parametrize('longshort', [LongShort.LONG, LongShort.SHORT])
-@pytest.mark.parametrize('putcall', [PutCallFwd.CALL, PutCallFwd.PUT])
-class TestGenericPayoff_Eu_Am_EuDig:
+@pytest.mark.parametrize('strike', np.arange(0.5, 2, 0.5))
+@pytest.mark.parametrize('long_short', [LongShort.LONG, LongShort.SHORT])
+class TestGenericPayoff:
+    underlying = Stock.EXAMPLE1
+    ref_spot = MarketData.get_initial_spot()[underlying]
     expiry = 2.0
 
-    def test_European_payoff(self, putcall, longshort, spot, strike):
-        trade = EuropeanContract('OTP', putcall, longshort, strike, self.expiry)
-        generic_trade = trade.convert_to_generic()
-        assert trade.payoff(spot) == pytest.approx(generic_trade.payoff(spot))
+    @pytest.mark.parametrize('spot', np.arange(0.5, 2, 0.5))
+    def test_forward_payoff(self, long_short, strike, spot):
+        spot = spot * self.ref_spot
+        strike = strike * self.ref_spot
+        contract = ForwardContract(self.underlying, long_short, strike, self.expiry)
+        generic = contract.convert_to_generic()
+        obs = {round(self.expiry, contract.TIMELINE_DIGITS): spot}
+        assert contract.payoff(obs) == pytest.approx(generic.payoff(obs))
 
-    def test_American_payoff(self, putcall, longshort, spot, strike):
-        trade = AmericanContract('Tesla', putcall, longshort, strike, self.expiry)
-        generic_trade = trade.convert_to_generic()
-        assert trade.payoff(spot) == pytest.approx(generic_trade.payoff(spot))
+    @pytest.mark.parametrize('spot', np.arange(0.5, 2, 0.5))
+    @pytest.mark.parametrize('put_call', [PutCallFwd.CALL, PutCallFwd.PUT])
+    def test_european_payoff(self, put_call, long_short, strike, spot):
+        spot = spot * self.ref_spot
+        strike = strike * self.ref_spot
+        contract = EuropeanContract(self.underlying, put_call, long_short, strike, self.expiry)
+        generic = contract.convert_to_generic()
+        obs = {round(self.expiry, contract.TIMELINE_DIGITS): spot}
+        assert contract.payoff(obs) == pytest.approx(generic.payoff(obs))
 
-    def test_EuropeanDigital_payoff(self, putcall, longshort, spot, strike):
-        trade = EuropeanDigitalContract('Mol', putcall, longshort, strike, self.expiry)
-        generic_trade = trade.convert_to_generic()
-        assert trade.payoff(spot) == pytest.approx(generic_trade.payoff(spot))
+    @pytest.mark.parametrize('spot', np.arange(0.5, 2, 0.5))
+    @pytest.mark.parametrize('put_call', [PutCallFwd.CALL, PutCallFwd.PUT])
+    def test_american_payoff(self, put_call, long_short, strike, spot):
+        spot = spot * self.ref_spot
+        strike = strike * self.ref_spot
+        contract = AmericanContract(self.underlying, put_call, long_short, strike, self.expiry)
+        generic = contract.convert_to_generic()
+        obs = {round(self.expiry, contract.TIMELINE_DIGITS): spot}
+        assert contract.payoff(obs) == pytest.approx(generic.payoff(obs))
 
+    @pytest.mark.parametrize('spot', np.arange(0.5, 2, 0.5))
+    @pytest.mark.parametrize('put_call', [PutCallFwd.CALL, PutCallFwd.PUT])
+    def test_european_digital_payoff(self, put_call, long_short, strike, spot):
+        spot = spot * self.ref_spot
+        strike = strike * self.ref_spot
+        contract = EuropeanDigitalContract(self.underlying, put_call, long_short, strike, self.expiry)
+        generic = contract.convert_to_generic()
+        obs = {round(self.expiry, contract.TIMELINE_DIGITS): spot}
+        assert contract.payoff(obs) == pytest.approx(generic.payoff(obs))
 
+    @pytest.mark.parametrize('spot', [np.arange(1.2, 0.7, -0.05), np.arange(1, 2, 0.1)])
+    @pytest.mark.parametrize('put_call', [PutCallFwd.CALL, PutCallFwd.PUT])
+    def test_asian_payoff(self, put_call, long_short, strike, spot):
+        spot = spot * self.ref_spot
+        strike = strike * self.ref_spot
+        num_mon = len(spot)
+        contract = AsianContract(self.underlying, put_call, long_short, strike, self.expiry, num_mon)
+        generic = contract.convert_to_generic()
+        obs = {round(((i + 1) / num_mon) * self.expiry, contract.TIMELINE_DIGITS): spot[i] for i in range(num_mon)}
+        assert contract.payoff(obs) == pytest.approx(generic.payoff(obs))
 
-@pytest.mark.parametrize('strike', np.arange(-1, 3, 0.5))
-@pytest.mark.parametrize('longshort', [LongShort.LONG, LongShort.SHORT])
-@pytest.mark.parametrize('putcall', [PutCallFwd.CALL, PutCallFwd.PUT])
-class TestGenericPayoff_Asian_Barr:
-    spot = np.arange(-1, 3, 0.5) 
-    expiry = 2.0
-
-    def test_Asian_payoff(self, putcall, longshort, strike):
-        trade = AsianContract('Microsoft', putcall, longshort, strike, self.expiry)
-        generic_trade = trade.convert_to_generic()
-        assert trade.payoff(self.spot) == pytest.approx(generic_trade.payoff(self.spot))
-
-    @pytest.mark.parametrize('updown', [UpDown.DOWN, UpDown.UP])
-    @pytest.mark.parametrize('inout', [InOut.IN, InOut.OUT])
-    @pytest.mark.parametrize('barrier', np.arange(-1, 3, 0.5))
-    def test_EuropeanBarrier_payoff(self, putcall, longshort, strike, updown, inout, barrier):
-        trade = EuropeanBarrierContract('Deutsche Bank', putcall, longshort, strike, self.expiry,
-                                        barrier, updown, inout)
-        generic_trade = trade.convert_to_generic()
-        assert trade.payoff(self.spot) == pytest.approx(generic_trade.payoff(self.spot))
-
+    @pytest.mark.parametrize('spot', [np.arange(1.2, 0.7, -0.05), np.arange(1, 2, 0.1)])
+    @pytest.mark.parametrize('put_call', [PutCallFwd.CALL, PutCallFwd.PUT])
+    @pytest.mark.parametrize('barrier', np.arange(0.9, 1.2, 0.2))
+    @pytest.mark.parametrize('up_down', [UpDown.DOWN, UpDown.UP])
+    @pytest.mark.parametrize('in_out', [InOut.IN, InOut.OUT])
+    def test_european_barrier_payoff(self, put_call, long_short, strike, barrier, up_down, in_out, spot):
+        spot = spot * self.ref_spot
+        strike = strike * self.ref_spot
+        barrier = barrier * self.ref_spot
+        num_mon = len(spot)
+        contract = EuropeanBarrierContract(
+            self.underlying, put_call, long_short, strike, self.expiry, num_mon, barrier, up_down, in_out)
+        generic = contract.convert_to_generic()
+        obs = {round(((i + 1) / num_mon) * self.expiry, contract.TIMELINE_DIGITS): spot[i] for i in range(num_mon)}
+        assert contract.payoff(obs) == pytest.approx(generic.payoff(obs))

--- a/test/test_pricer.py
+++ b/test/test_pricer.py
@@ -5,7 +5,7 @@ from src.pricer import *
 MarketData.initialize()
 
 
-@pytest.mark.parametrize('ref_strike', [0.9, 1.0])
+@pytest.mark.parametrize('strike', [0.9, 1.0])
 @pytest.mark.parametrize('expiry', [0.5, 2.0])
 class TestForwardAnalyticPricer:
     MarketData.initialize()
@@ -14,26 +14,26 @@ class TestForwardAnalyticPricer:
     model = FlatVolModel(und)
     method = AnalyticMethod(model)
 
-    def test_fair_value(self, ref_strike, expiry):
+    def test_fair_value(self, strike, expiry):
         expected_result = {
             (round(0.9, 1), round(0.5, 1)): 12.22210791745006,
             (round(0.9, 1), round(2.0, 1)): 18.56463237676364,
             (round(1.0, 1), round(0.5, 1)): 2.4690087971667367,
             (round(1.0, 1), round(2.0, 1)): 9.516258196404053
         }
-        strike = ref_strike * MarketData.get_initial_spot()[self.und]
-        contract = ForwardContract(self.und, self.ls, strike, expiry)
+        strike_level = strike * MarketData.get_initial_spot()[self.und]
+        contract = ForwardContract(self.und, self.ls, strike_level, expiry)
         pricer = ForwardAnalyticPricer(contract, self.model, self.method)
         fv = pricer.calc_fair_value()
-        assert fv == pytest.approx(expected_result[(round(ref_strike, 1), round(expiry, 1))])
+        assert fv == pytest.approx(expected_result[(round(strike, 1), round(expiry, 1))])
 
     @pytest.mark.parametrize('greek_method', [GreekMethod.ANALYTIC, GreekMethod.BUMP])
-    def test_delta(self, ref_strike, expiry, greek_method):
+    def test_delta(self, strike, expiry, greek_method):
         expected_result = {
             GreekMethod.ANALYTIC: 1.0,
             GreekMethod.BUMP: 1.0
         }
-        strike = ref_strike * MarketData.get_initial_spot()[self.und]
+        strike = strike * MarketData.get_initial_spot()[self.und]
         contract = ForwardContract(self.und, self.ls, strike, expiry)
         pricer = ForwardAnalyticPricer(contract, self.model, self.method)
         delta = pricer.calc_delta(greek_method)


### PR DESCRIPTION
Instead of distinguishing VanillaContract (payoff takes single float as input) and ExoticContract (payoff takes vector of float as input), I have removed these classes so each subclass inherits from Contract base class. The payoff function has been redesigned to take a dictionary of (time, spot price) values.

I refactored GenericContract and Barrier classes.
I refactored and enhanced contract tests.